### PR TITLE
Don't display checkmark on empty recovery email

### DIFF
--- a/email_login/src/components/SignUpModel.js
+++ b/email_login/src/components/SignUpModel.js
@@ -1,0 +1,7 @@
+import { toBeConfirmed } from './SignUpSymbols';
+
+export const shouldDisableSubmitButton = state => {
+  return Object.values(state.errors).some(
+    errMsg => (typeof errMsg === 'string') | (errMsg === toBeConfirmed)
+  );
+};

--- a/email_login/src/components/SignUpModel.test.js
+++ b/email_login/src/components/SignUpModel.test.js
@@ -1,0 +1,68 @@
+import { optionallyEmpty } from './SignUpSymbols';
+import { createStore } from './SignUpStore';
+import { shouldDisableSubmitButton } from './SignUpModel';
+
+const defaultState = createStore();
+const withErrors = errors => ({
+  ...defaultState,
+  errors: { ...defaultState.errors, ...errors }
+});
+
+describe('shouldDisableSubmitButton', () => {
+  it.each([
+    [defaultState, true],
+    [withErrors({ username: 'error' }), true],
+    [withErrors({ password: 'error' }), true],
+    [withErrors({ confirmpassword: 'error' }), true],
+    [withErrors({ recoveryemail: 'error' }), true],
+    [withErrors({ fullname: 'error' }), true],
+    [
+      withErrors({
+        username: 'error',
+        password: 'error',
+        confirmpassword: 'error',
+        recoveryemail: 'error',
+        fullname: 'error'
+      }),
+      true
+    ],
+    [
+      withErrors({
+        username: undefined,
+        password: undefined,
+        fullname: undefined,
+        confirmpassword: undefined,
+        recoveryemail: 'error',
+        acceptterms: undefined
+      }),
+      true
+    ],
+    [
+      withErrors({
+        username: undefined,
+        password: undefined,
+        fullname: undefined,
+        confirmpassword: undefined,
+        recoveryemail: undefined,
+        acceptterms: undefined
+      }),
+      false
+    ],
+    [
+      withErrors({
+        username: undefined,
+        password: undefined,
+        fullname: undefined,
+        confirmpassword: undefined,
+        recoveryemail: optionallyEmpty,
+        acceptterms: undefined
+      }),
+      false
+    ]
+  ])(
+    'validates that state #%# is ready to submit sign up form',
+    (state, isReady) => {
+      expect(shouldDisableSubmitButton(state)).toBe(isReady);
+    }
+  );
+});

--- a/email_login/src/components/SignUpReducers.js
+++ b/email_login/src/components/SignUpReducers.js
@@ -1,4 +1,4 @@
-import { toBeConfirmed } from './SignUpSymbols';
+import { toBeConfirmed, optionallyEmpty } from './SignUpSymbols';
 import * as ErrorMsgs from './SignUpErrorMsgs';
 import {
   validateUsername,
@@ -118,7 +118,16 @@ export const updateForm = (state, { itemName, itemValue }) => {
           };
     }
     case 'recoveryemail': {
-      return itemValue === '' || validateEmail(itemValue)
+      if (itemValue === '')
+        return {
+          ...newState,
+          errors: {
+            ...newState.errors,
+            recoveryemail: optionallyEmpty
+          }
+        };
+
+      return validateEmail(itemValue)
         ? newState
         : {
             ...newState,

--- a/email_login/src/components/SignUpReducers.test.js
+++ b/email_login/src/components/SignUpReducers.test.js
@@ -1,6 +1,6 @@
 import { check, gen, property } from 'testcheck';
 
-import { toBeConfirmed } from './SignUpSymbols';
+import { toBeConfirmed, optionallyEmpty } from './SignUpSymbols';
 import { createStore } from './SignUpStore';
 import {
   checkUsername,
@@ -227,6 +227,7 @@ describe('updateForm', () => {
     input                      | error
     ${'gabriel'}               | ${ErrorMsgs.EMAIL_INVALID}
     ${'gabriel@io'}            | ${ErrorMsgs.EMAIL_INVALID}
+    ${''}                      | ${optionallyEmpty}
     ${'gabriel@gmail.com'}     | ${undefined}
     ${'vv22-_ga.Eom@live.com'} | ${undefined}
   `('With email: $input sets error: $error', ({ input, error }) => {

--- a/email_login/src/components/SignUpStore.js
+++ b/email_login/src/components/SignUpStore.js
@@ -1,4 +1,4 @@
-import { toBeConfirmed } from './SignUpSymbols';
+import { toBeConfirmed, optionallyEmpty } from './SignUpSymbols';
 export const formItems = [
   {
     name: 'username',
@@ -96,7 +96,7 @@ const onInitState = (array, field) =>
 const onInitErrors = (array, field) =>
   array.reduce((obj, item) => {
     // eslint-disable-next-line fp/no-mutation
-    obj[item[field]] = item.optional ? undefined : toBeConfirmed;
+    obj[item[field]] = item.optional ? optionallyEmpty : toBeConfirmed;
     return obj;
   }, {});
 

--- a/email_login/src/components/SignUpSymbols.js
+++ b/email_login/src/components/SignUpSymbols.js
@@ -1,1 +1,2 @@
 export const toBeConfirmed = Symbol('toBeConfirmed');
+export const optionallyEmpty = Symbol('optionallyEmpty');

--- a/email_login/src/components/SignUpWrapper.js
+++ b/email_login/src/components/SignUpWrapper.js
@@ -5,10 +5,7 @@ import { hashPassword } from '../utils/HashUtils';
 import { toBeConfirmed } from './SignUpSymbols';
 import { formItems, createStore } from './SignUpStore';
 import * as reducers from './SignUpReducers';
-
-const isSignUpButtonDisabled = errors => {
-  return Object.values(errors).some(errMsg => errMsg);
-};
+import * as model from './SignUpModel';
 
 class SignUpWrapper extends Component {
   constructor(props) {
@@ -26,7 +23,7 @@ class SignUpWrapper extends Component {
           onChangeField={this.handleChange}
           onClickSignUp={this.handleClickSignUp}
           errors={this.state.errors}
-          disabled={isSignUpButtonDisabled(this.state.errors)}
+          disabled={model.shouldDisableSubmitButton(this.state)}
           isShowingPassword={this.state.isShowingPassword}
           onToggleShowPassword={this.onToggleShowPassword}
         />


### PR DESCRIPTION
Add new sign up symbol: optionallyEmpty.
Create module SignUpModel with function shouldDisableSubmitButton to
for easier testing.
On sign-up form don't display checkmark on empty recovery email.

Closes #487