### PR TITLE
update jquery to remove warning

### DIFF
--- a/email_composer/package.json
+++ b/email_composer/package.json
@@ -11,7 +11,7 @@
     "crypto-js": "^3.1.9-1",
     "draftjs-to-html": "^0.8.2",
     "immutable": "^3.8.2",
-    "jquery": "^3.3.1",
+    "jquery": "^3.4.0",
     "moment": "^2.22.2",
     "randomcolor": "^0.5.3",
     "react": "^16.2.0",

--- a/email_composer/yarn.lock
+++ b/email_composer/yarn.lock
@@ -5633,9 +5633,10 @@ joi@^11.1.1:
     isemail "3.x.x"
     topo "2.x.x"
 
-jquery@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+jquery@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.4.9"


### PR DESCRIPTION
- Update JQuery to remove warning on versions prior 3.4.0