### PR TITLE
Fix: Missing loading window

### DIFF
--- a/electron_app/src/ipc/utils.js
+++ b/electron_app/src/ipc/utils.js
@@ -53,7 +53,7 @@ const sendLinkDeviceStartEventToAllWindows = async data => {
     loadingType: 'link-device-request',
     remoteData: data.params.newDeviceInfo
   });
-  loadingWindow.show();
+  loadingWindow.show({});
   return await clientManager.acknowledgeEvents([data.rowid]);
 };
 
@@ -82,7 +82,7 @@ const sendSyncMailboxStartEventToAllWindows = async data => {
       version: data.params.version
     })
   });
-  loadingWindow.show();
+  loadingWindow.show({});
   return await clientManager.acknowledgeEvents([data.rowid]);
 };
 


### PR DESCRIPTION
- `loadingWindow.show()` receives and object with `type` param
- You should pass and an empty object by default