### PR TITLE
fixing error when receiving only one event

### DIFF
--- a/email_mailbox/src/utils/electronEventInterface.js
+++ b/email_mailbox/src/utils/electronEventInterface.js
@@ -221,8 +221,8 @@ const parseAndDispatchEvent = async event => {
       threadIds,
       labels,
       badgeLabelIds,
-      removedLabels: [removedLabel],
-      updatedLabels: [updatedLabel]
+      removedLabels: removedLabel ? [removedLabel] : null,
+      updatedLabels: updatedLabel ? [updatedLabel] : null
     });
   } catch (error) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
- Single event can be called and not being email related so it won't have any removed nor updated labels