### PR TITLE
bump version to 0.26.3

### DIFF
--- a/electron_app/package.json
+++ b/electron_app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "criptext",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "author": {
     "name": "Criptext Inc",
     "email": "support@criptext.com",

--- a/electron_app/src/aliceManager.js
+++ b/electron_app/src/aliceManager.js
@@ -84,7 +84,13 @@ const startAlice = async () => {
     const dbpath = path.resolve(dbManager.databasePath);
     const logspath = path.resolve(getLogsPath(process.env.NODE_ENV));
     await cleanAliceRemenants();
-    alice = spawn(alicePath, [dbpath, myPort, logspath, password]);
+    alice = spawn(alicePath, [
+      dbpath,
+      myPort,
+      logspath,
+      password,
+      '--no-sandbox'
+    ]);
     alice.stdout.on('data', data => {
       console.log(`-----alice-----\n${data}\n -----end-----`);
     });

--- a/email_composer/package.json
+++ b/email_composer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email_composer",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "private": true,
   "dependencies": {
     "@criptext/electron-better-ipc": "^0.7.0-rc1-0.2",

--- a/email_loading/package.json
+++ b/email_loading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email_loading",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "private": true,
   "dependencies": {
     "@criptext/electron-better-ipc": "^0.7.0-rc1-0.2",

--- a/email_login/package.json
+++ b/email_login/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email_login",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "private": true,
   "dependencies": {
     "@criptext/electron-better-ipc": "^0.7.0-rc1-0.2",

--- a/email_mailbox/package.json
+++ b/email_mailbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email_mailbox",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "private": true,
   "dependencies": {
     "@criptext/electron-better-ipc": "^0.7.0-rc1-0.2",


### PR DESCRIPTION
- Bump version 0.26.3
- running `Criptext-Encryption-Service` with `--no-sandbox` to avoid immediate shutdown of service