### PR TITLE
Fixing DB Path and Closing Old DB Connection

### DIFF
--- a/electron_app/src/database/DBEmodel.js
+++ b/electron_app/src/database/DBEmodel.js
@@ -12,6 +12,8 @@ const { parseDate, formatDate } = require('./../utils/TimeUtils');
 let sequelize;
 
 const getDbEncryptPath = node_env => {
+  const currentDirToReplace =
+    process.platform === 'win32' ? '\\src\\database' : '/src/database';
   switch (node_env) {
     case 'test': {
       return './src/__integrations__/test.db';
@@ -20,14 +22,14 @@ const getDbEncryptPath = node_env => {
       return path
         .join(__dirname, '/CriptextEncrypt.db')
         .replace('/app.asar', '')
-        .replace('/src/database', '');
+        .replace(currentDirToReplace, '');
     }
     default: {
       const userDataPath = app.getPath('userData');
       return path
         .join(userDataPath, '/CriptextEncrypt.db')
         .replace('/app.asar', '')
-        .replace('/src/database', '');
+        .replace(currentDirToReplace, '');
     }
   }
 };

--- a/electron_app/src/database/DBManager.js
+++ b/electron_app/src/database/DBManager.js
@@ -1367,8 +1367,7 @@ const formStringSeparatedByOperator = (array, operator = ',') => {
 };
 
 const closeDB = () => {
-  db.close();
-  db.disconnect();
+  return db.destroy();
 };
 
 module.exports = {

--- a/electron_app/src/database/models.js
+++ b/electron_app/src/database/models.js
@@ -7,6 +7,8 @@ const { app } = require('electron');
 const knexfile = require('./../knexfile');
 
 const getDbPath = node_env => {
+  const currentDirToReplace =
+    process.platform === 'win32' ? '\\src\\database' : '/src/database';
   switch (node_env) {
     case 'test': {
       return './src/__integrations__/test.db';
@@ -15,14 +17,14 @@ const getDbPath = node_env => {
       return path
         .join(__dirname, '/Criptext.db')
         .replace('/app.asar', '')
-        .replace('/src/database', '');
+        .replace(currentDirToReplace, '');
     }
     default: {
       const userDataPath = app.getPath('userData');
       return path
         .join(userDataPath, '/Criptext.db')
         .replace('/app.asar', '')
-        .replace('/src/database', '');
+        .replace(currentDirToReplace, '');
     }
   }
 };
@@ -35,6 +37,7 @@ const dbConfiguration = {
   },
   useNullAsDefault: false
 };
+
 const migrationConfig = Object.assign(knexfile, dbConfiguration);
 
 const TINY_STRING_SIZE = 8;

--- a/electron_app/src/utils/dataBaseUtils.js
+++ b/electron_app/src/utils/dataBaseUtils.js
@@ -63,6 +63,8 @@ const deleteFile = async filepath => {
 };
 
 const getFilenamePath = (node_env, filename) => {
+  const currentDirToReplace =
+    process.platform === 'win32' ? '\\src\\utils' : '/src/utils';
   switch (node_env) {
     case 'test': {
       return './src/__integrations__/test.db';
@@ -71,7 +73,7 @@ const getFilenamePath = (node_env, filename) => {
       const a = path
         .join(__dirname, `/${filename}`)
         .replace('/app.asar', '')
-        .replace('/src/utils', '');
+        .replace(currentDirToReplace, '');
       return a;
     }
     default: {
@@ -79,7 +81,7 @@ const getFilenamePath = (node_env, filename) => {
       return path
         .join(userDataPath, `/${filename}`)
         .replace('/app.asar', '')
-        .replace('/src/utils', '');
+        .replace(currentDirToReplace, '');
     }
   }
 };

--- a/electron_app/src/windows/index.js
+++ b/electron_app/src/windows/index.js
@@ -22,6 +22,7 @@ const upStepDBEncryptedWithoutPIN = async () => {
   const [existingAccount] = await dbManager.getAccount();
   if (existingAccount) {
     await pinWindow.show();
+    await dbManager.closeDB();
   } else {
     throw new Error('empty not encrytDatabase');
   }


### PR DESCRIPTION
- Windows path for development were wrong
- Windows can't remove old DB file if a connection with the file is active; the connection is being closed before deleting file