### PR TITLE
Socket connection allows multiple jwt

### DIFF
--- a/electron_app/electron-starter.js
+++ b/electron_app/electron-starter.js
@@ -1,6 +1,6 @@
 const { app, ipcMain } = require('electron');
 const myAccount = require('./src/Account');
-const wsClient = require('./src/socketClient');
+const socketClient = require('./src/socketClient');
 const globalManager = require('./src/globalManager');
 const mySettings = require('./src/Settings');
 const { dbManager, upStepDBEncryptedWithoutPIN, upStepCheckPINDBEncrypted } = require('./src/windows');
@@ -53,7 +53,7 @@ async function initApp() {
       mySettings.initialize(settings);
       await initClient();
       initNucleus({language: mySettings.language});
-      wsClient.start(myAccount);
+      socketClient.start(myAccount);
       createAppMenu();
       mailboxWindow.show({ firstOpenApp: true });
     }
@@ -97,7 +97,7 @@ async function initApp() {
   });
 
   // Socket
-  wsClient.setMessageListener(async data => {
+  socketClient.setMessageListener(async data => {
     const SIGNIN_VERIFICATION_REQUEST_COMMAND = 201;
     const MANUAL_SYNC_REQUEST_COMMAND = 211;
     // This validation is for closed-mailbox case

--- a/electron_app/src/clientManager.js
+++ b/electron_app/src/clientManager.js
@@ -135,7 +135,7 @@ const checkExpiredSession = async (
           recipientId
         });
         if (client.token) client.token = newSessionToken;
-        socketClient.restartSocket({ jwt: newSessionToken });
+        socketClient.add({ recipientId, jwt: newSessionToken });
         if (initialRequest) {
           return await initialRequest(requestparams);
         }

--- a/electron_app/src/ipc/mailbox.js
+++ b/electron_app/src/ipc/mailbox.js
@@ -7,7 +7,7 @@ const mailboxWindow = require('../windows/mailbox');
 const { installUpdate, checkForUpdates } = require('./../updater');
 const { showNotification } = require('./../notificationManager');
 const myAccount = require('./../Account');
-const wsClient = require('./../socketClient');
+const socketClient = require('./../socketClient');
 const { printEmailOrThread } = require('./../utils/PrintUtils');
 const { buildEmailSource } = require('../utils/SourceUtils');
 const {
@@ -17,7 +17,6 @@ const {
 } = require('../utils/FileUtils');
 const { getUsername, genUUID } = require('./../utils/stringUtils');
 const { showWindows } = require('./../windows/windowUtils');
-const { restartSocket } = require('./../socketClient');
 const { checkAlive } = require('./../reachabilityTask');
 const { restartAlice } = require('./../aliceManager');
 
@@ -47,7 +46,7 @@ ipc.answerRenderer('open-file-explorer', filename => {
 });
 
 ipc.answerRenderer('open-mailbox', ({ firstOpenApp }) => {
-  wsClient.start(myAccount);
+  socketClient.add({ jwt: myAccount.jwt, recipientId: myAccount.recipientId });
   mailboxWindow.show({ firstOpenApp });
 });
 
@@ -126,8 +125,8 @@ ipc.answerRenderer('check-for-updates', showDialog => {
 
 ipc.answerRenderer('generate-label-uuid', genUUID);
 
-ipc.answerRenderer('restart-connection', jwt => {
-  restartSocket({ jwt });
+ipc.answerRenderer('restart-connection', () => {
+  socketClient.restartSocket();
   checkAlive(true);
 });
 

--- a/electron_app/src/reachabilityTask.js
+++ b/electron_app/src/reachabilityTask.js
@@ -2,7 +2,7 @@ const { SERVER_URL } = require('./utils/const');
 const globalManager = require('./globalManager');
 const mailboxWindow = require('./windows/mailbox');
 const { processEventsQueue } = require('./eventQueueManager');
-const { restartSocketSameJWT } = require('./socketClient');
+const { restartSocket } = require('./socketClient');
 const reconnectDelay = 2000;
 const NETWORK_STATUS = {
   ONLINE: 'online',
@@ -61,7 +61,7 @@ const checkAlive = async force => {
     }
     if (hasFailed) {
       hasFailed = false;
-      restartSocketSameJWT();
+      restartSocket(true);
     }
   } catch (ex) {
     hasFailed = true;

--- a/electron_app/src/windows/index.js
+++ b/electron_app/src/windows/index.js
@@ -7,7 +7,7 @@ const mailboxWindow = require('./mailbox');
 const pinWindow = require('./pin');
 const { EVENTS, addEvent } = require('./events');
 const { createAppMenu } = require('./menu');
-const wsClient = require('./../socketClient');
+const socketClient = require('./../socketClient');
 const { initClient, generateEvent } = require('./../clientManager');
 const { initNucleus } = require('./../nucleusManager');
 const globalManager = require('./../globalManager');
@@ -89,7 +89,7 @@ const upMailboxWindow = async existingAccount => {
   mySettings.initialize(settings);
   await initClient();
   initNucleus({ language: mySettings.language });
-  wsClient.start(myAccount);
+  socketClient.add({ jwt: myAccount.jwt, recipientId: myAccount.recipientId });
   createAppMenu();
   mailboxWindow.show({ firstOpenApp: true });
   if (pinWindow) pinWindow.close({ forceClose: true });

--- a/email_loading/src/utils/electronInterface.js
+++ b/email_loading/src/utils/electronInterface.js
@@ -1,6 +1,6 @@
 import { labels } from './systemLabels';
 const { remote } = window.require('electron');
-const socketManager = remote.require('./src/socketClient');
+const socketClient = remote.require('./src/socketClient');
 const globalManager = remote.require('./src/globalManager');
 
 export const myAccount = remote.require('./src/Account');
@@ -23,12 +23,11 @@ export const setRemoteData = data => {
 };
 
 export const startSocket = jwt => {
-  const data = jwt ? { jwt } : myAccount;
-  socketManager.start(data);
+  socketClient.start(jwt);
 };
 
 export const stopSocket = () => {
-  return socketManager.disconnect();
+  return socketClient.disconnect();
 };
 
 export const isFromStore =

--- a/email_mailbox/src/containers/Message.js
+++ b/email_mailbox/src/containers/Message.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { MessageType } from '../components/Message';
 import MessageWrapper from './../components/MessageWrapper';
 import MessageContent, { actionHandlerKeys } from './../data/message';
-import { LabelType, myAccount } from './../utils/electronInterface';
+import { LabelType } from './../utils/electronInterface';
 import { installUpdate, restartConnection } from './../utils/ipc';
 import { SectionType } from '../utils/const';
 import { loadThreads, updateUnreadThreads } from '../actions';
@@ -110,7 +110,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
           break;
         }
         case actionHandlerKeys.error.network: {
-          await restartConnection(myAccount.jwt);
+          await restartConnection();
           break;
         }
         default:

--- a/email_mailbox/src/utils/electronEventInterface.js
+++ b/email_mailbox/src/utils/electronEventInterface.js
@@ -1308,7 +1308,7 @@ ipcRenderer.on('socket-message', async (ev, message) => {
 });
 
 ipc.answerMain('get-events', async () => {
-  await restartConnection(myAccount.jwt);
+  await restartConnection();
   sendLoadEventsEvent({});
 });
 

--- a/email_mailbox/src/utils/ipc.js
+++ b/email_mailbox/src/utils/ipc.js
@@ -66,10 +66,6 @@ export const restartAlice = async () => {
 
 export const restartApp = () => ipc.callMain('restart-app');
 
-export const restartSocket = async jwt => {
-  await ipc.callMain('restart-socket', jwt);
-};
-
 export const sendEndSyncDevicesEvent = async () => {
   await ipc.callMain('close-create-keys-loading');
   return await ipc.callMain('end-sync-mailbox-event');


### PR DESCRIPTION
Having a list of recipientIds/jwts to allow multiple accounts
- If the recipient id already exists, the couple is updated with the new jwt
- reconnect allows for the use of previous jwt or a newly made jwt-string