### PR TITLE
3 dots and image load fix

### DIFF
--- a/email_mailbox/src/components/EmailWrapper.js
+++ b/email_mailbox/src/components/EmailWrapper.js
@@ -24,9 +24,9 @@ class EmailWrapper extends Component {
       buttonUnsendStatus: ButtonUnsendStatus.NORMAL,
       buttonReplyStatus: ButtonStatus.NORMAL,
       displayEmail: false,
-      blockImagesInline: false,
-      blockImagesContact: false,
-      blockImagesAccount: false,
+      blockImagesInline: true,
+      blockImagesContact: true,
+      blockImagesAccount: true,
       isHiddenPopOverEmailActions: true,
       isHiddenPopOverEmailMoreInfo: true,
       isHiddenPopOverEmailBlocked: true,
@@ -230,17 +230,12 @@ class EmailWrapper extends Component {
         hasImages,
         isFromMe
       });
-      this.setState(
-        {
-          displayEmail: !displayEmail,
-          blockImagesInline: blockingInline,
-          blockImagesContact,
-          blockImagesAccount
-        },
-        () => {
-          this.setCollapseListener('add');
-        }
-      );
+      this.setState({
+        displayEmail: !displayEmail,
+        blockImagesInline: blockingInline,
+        blockImagesContact,
+        blockImagesAccount
+      });
     }
   };
 


### PR DESCRIPTION
- 3 Dots expanding and collapsing old emails in a thread
- Initial block status is true to prevent images from blinking